### PR TITLE
Fix typo in installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Installation
 
 Example podfile:
 
-	pod 'YBLStatechart', '1.0.1'
+	pod 'YBStatechart', '1.0.1'
 
 
 License


### PR DESCRIPTION
Fixes #6 - Typo in README

Fixes a typo in the installation section of the README.
